### PR TITLE
Add Rackspace Identity v2 authentication interceptor

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -28,7 +28,7 @@ interceptors to inject authentication tokens, etc
 
 Quick example
 
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl("http://your.own.domain")
 
 	type MsgHolder struct {
@@ -42,5 +42,5 @@ Quick example
 		restclient.NewJsonEntity(req), restclient.NewJsonEntity(&resp))
 
   	fmt.Println(resp.Msg)
- */
+*/
 package restclient

--- a/identityv2.go
+++ b/identityv2.go
@@ -1,0 +1,123 @@
+package restclient
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const authTimeout = 60 * time.Second
+
+type identityV2AuthenticatorImpl struct {
+	username string
+	password string
+	apikey   string
+
+	restClient *Client
+
+	token           string
+	tokenExpiration time.Time
+}
+
+// IdentityV2Authenticator provides an implementation of the Rackspace Cloud Identity v2.0
+// authentication flow.
+// The identityUrl should be the base URL of the Identity endpoint, such as "https://identity.api.rackspacecloud.com".
+// Either password or apikey can be provided with the other passed an empty string.
+//
+// Info about Identity v2.0 is available at https://developer.rackspace.com/docs/cloud-identity/v2/
+func IdentityV2Authenticator(identityUrl string, username string, password string, apikey string) (Interceptor, error) {
+	if username == "" {
+		return nil, errors.New("username is required")
+	}
+	if password == "" && apikey == "" {
+		return nil, errors.New("password or Apikey is required")
+	}
+
+	// looks slightly convoluted, but dogfood our own library to access the Identity REST API
+	restClient := New()
+	err := restClient.SetBaseUrl(identityUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Identity URL: %w", err)
+	}
+	restClient.Timeout = authTimeout
+
+	impl := &identityV2AuthenticatorImpl{
+		username:   username,
+		password:   password,
+		apikey:     apikey,
+		restClient: restClient,
+	}
+
+	return impl.intercept, nil
+}
+
+type identityAuthApikeyReq struct {
+	Auth struct {
+		Credentials struct {
+			Username string `json:"username"`
+			Apikey   string `json:"apiKey"`
+		} `json:"RAX-KSKEY:apiKeyCredentials"`
+	} `json:"auth"`
+}
+
+type identityAuthPasswordReq struct {
+	Auth struct {
+		Credentials struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		} `json:"passwordCredentials"`
+	} `json:"auth"`
+}
+
+// identityAuthResp only picks out the fields needed and ignores the majority of response content
+type identityAuthResp struct {
+	Access struct {
+		Token struct {
+			Id      string
+			Expires time.Time
+		}
+	}
+}
+
+func (a *identityV2AuthenticatorImpl) intercept(req *http.Request, next NextCallback) (*http.Response, error) {
+	if time.Now().After(a.tokenExpiration) {
+		if err := a.authenticate(); err != nil {
+			return nil, err
+		}
+	}
+
+	// inject the auth token into the user's REST request
+	req.Header.Set("x-auth-token", a.token)
+
+	return next(req)
+}
+
+func (a *identityV2AuthenticatorImpl) authenticate() error {
+
+	var req interface{}
+	if a.apikey != "" {
+		auth := &identityAuthApikeyReq{}
+		auth.Auth.Credentials.Username = a.username
+		auth.Auth.Credentials.Apikey = a.apikey
+		req = auth
+	} else {
+		auth := &identityAuthPasswordReq{}
+		auth.Auth.Credentials.Username = a.username
+		auth.Auth.Credentials.Password = a.password
+		req = auth
+	}
+
+	var resp identityAuthResp
+
+	err := a.restClient.Exchange("POST", "/v2.0/tokens", nil,
+		NewJsonEntity(req), NewJsonEntity(&resp))
+	if err != nil {
+		return fmt.Errorf("failed to issue token request: %w", err)
+	}
+
+	a.token = resp.Access.Token.Id
+	a.tokenExpiration = resp.Access.Token.Expires
+
+	return nil
+}

--- a/identityv2.go
+++ b/identityv2.go
@@ -35,7 +35,7 @@ func IdentityV2Authenticator(identityUrl string, username string, password strin
 	}
 
 	// looks slightly convoluted, but dogfood our own library to access the Identity REST API
-	restClient := New()
+	restClient := NewClient()
 	err := restClient.SetBaseUrl(identityUrl)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Identity URL: %w", err)

--- a/identityv2_test.go
+++ b/identityv2_test.go
@@ -1,0 +1,23 @@
+package restclient_test
+
+import (
+	"github.com/racker/go-restclient"
+	"log"
+)
+
+func ExampleIdentityV2Authenticator() {
+	authenticator, err := restclient.IdentityV2Authenticator(
+		"https://identity.api.rackspacecloud.com",
+		"username", "", "apikey")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	client := restclient.New()
+	client.AddInterceptor(authenticator)
+
+	// calls to client.Exchange will get x-auth-token auto populated by interceptor
+
+	// Output:
+	//
+}

--- a/identityv2_test.go
+++ b/identityv2_test.go
@@ -13,7 +13,7 @@ func ExampleIdentityV2Authenticator() {
 		log.Fatal(err)
 	}
 
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.AddInterceptor(authenticator)
 
 	// calls to client.Exchange will get x-auth-token auto populated by interceptor

--- a/restclient.go
+++ b/restclient.go
@@ -76,7 +76,7 @@ func (r *FailedResponseError) Error() string {
 	return r.Status
 }
 
-func New() *Client {
+func NewClient() *Client {
 	return &Client{}
 }
 

--- a/restclient_test.go
+++ b/restclient_test.go
@@ -38,7 +38,7 @@ func Example_post() {
 	defer ts.Close()
 
 	// Real example starts here
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl(ts.URL)
 
 	type MsgHolder struct {
@@ -69,7 +69,7 @@ func Example_getWithQuery() {
 	defer ts.Close()
 
 	// Real example starts here
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl(ts.URL)
 
 	query := make(url.Values)
@@ -104,7 +104,7 @@ func Example_postText() {
 	defer ts.Close()
 
 	// Real example starts here
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl(ts.URL)
 
 	err := client.Exchange("POST", "/ingest", nil,
@@ -126,7 +126,7 @@ func Example_interceptorSetHeader() {
 	defer ts.Close()
 
 	// Real example starts here
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl(ts.URL)
 	client.AddInterceptor(func(req *http.Request, next restclient.NextCallback) (*http.Response, error) {
 		req.Header.Set("x-req-id", "123")
@@ -157,7 +157,7 @@ func Example_interceptorLogging() {
 	defer ts.Close()
 
 	// Real example starts here
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl(ts.URL)
 	client.AddInterceptor(func(req *http.Request, next restclient.NextCallback) (*http.Response, error) {
 		fmt.Printf("OUT %s %s\n", req.Method, req.URL.Path)
@@ -193,7 +193,7 @@ func Example_externalEncoding() {
 	defer ts.Close()
 
 	// Real example starts here
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl(ts.URL)
 
 	type MsgHolder struct {
@@ -242,7 +242,7 @@ func Example_decodeError() {
 	defer ts.Close()
 
 	// Real example starts here
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl(ts.URL)
 
 	type MsgHolder struct {
@@ -271,7 +271,7 @@ func ExampleBasicAuth() {
 	defer ts.Close()
 
 	// Real example starts here
-	client := restclient.New()
+	client := restclient.NewClient()
 	client.SetBaseUrl(ts.URL)
 	client.AddInterceptor(restclient.BasicAuth("admin", "notsecret"))
 


### PR DESCRIPTION
During a PR review I realized that the Identity authentication was still buried in the application module that originally prompted this restclient library

https://github.com/Rackspace-Segment-Support/salus-perf-test/pull/1#discussion_r362052006